### PR TITLE
feat(server): Implement T7 Server TUN & Forwarding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
@@ -105,6 +111,16 @@ name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
+name = "cc"
+version = "1.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "590f9024a68a8c40351881787f1934dc11afd69090f5edb6831464694d836ea3"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -165,6 +181,101 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e178e4fba8a2726903f6ba98a6d221e76f9c12c650d5dc0e6afdc50677b49650"
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,7 +309,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.3",
  "cfg-if",
  "libc",
 ]
@@ -250,6 +361,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,11 +391,24 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
+dependencies = [
+ "bitflags 1.3.2",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nix"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.3",
  "cfg-if",
  "libc",
 ]
@@ -327,7 +460,7 @@ name = "onebox-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "nix",
+ "nix 0.27.1",
  "serde",
  "serde_json",
  "thiserror",
@@ -344,6 +477,7 @@ dependencies = [
  "clap",
  "onebox-core",
  "tokio",
+ "tokio-tun",
  "tracing",
  "tracing-subscriber",
 ]
@@ -378,6 +512,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,7 +541,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.3",
 ]
 
 [[package]]
@@ -471,6 +611,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -578,6 +724,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-tun"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd88f1eab5997a7ac38dc7c14f039aac86b90e942a409488bec49be38286be5"
+dependencies = [
+ "futures",
+ "libc",
+ "nix 0.23.2",
+ "tokio",
 ]
 
 [[package]]

--- a/changelog/UNRELEASED.md
+++ b/changelog/UNRELEASED.md
@@ -9,6 +9,7 @@ This document tracks upcoming changes and features that are planned for future r
 - **Basic UDP Server**: Implemented a basic UDP server in `onebox-server` that listens for incoming datagrams and logs them. (T4)
 - **Basic UDP Client**: Implemented a basic UDP client in `onebox-client` that sends a "Hello Onebox" message to the server. (T5)
 - **Client TUN Creation**: Implemented TUN interface creation and configuration on the client. (T6)
+- **Server TUN & Forwarding**: Implemented TUN interface creation, IP forwarding, and NAT masquerading on the server. (T7)
 
 ### Planned Features
 - **Basic Networking**: UDP server and client communication
@@ -50,7 +51,7 @@ This document tracks upcoming changes and features that are planned for future r
 - **T4**: Basic UDP Server - `Done`
 - **T5**: Basic UDP Client - `Done`
 - **T6**: Client TUN & Routing - `Done`
-- **T7**: Server TUN & Forwarding - `To Do`
+- **T7**: Server TUN & Forwarding - `Done`
 
 ### Phase 3: Core Bonding Engine (Planned)
 - **T8**: E2E Ping Tunnel - `To Do`

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -27,7 +27,7 @@ This document contains the complete list of tasks required to implement the oneb
 | **T4** | **Basic UDP Server**: In `onebox-server`, create a basic Tokio UDP server that listens on a port and logs any data it receives. | FR-S-02 | TS0.2 | `Done` | High |
 | **T5** | **Basic UDP Client**: In `onebox-client`, create a basic client that sends a "Hello Onebox" message to the server's address. | FR-C-04 | TS0.3 | `Done` | High |
 | **T6** | **Client TUN & Routing**: In `onebox-client`, implement TUN interface creation and modify the system routing table to capture traffic. | FR-C-01, FR-C-02, SI-1 | TS0.1 | `Done` | High |
-| **T7** | **Server TUN & Forwarding**: In `onebox-server`, implement TUN interface creation and basic NAT/forwarding rules. | FR-S-01, FR-S-04 | N/A | `To Do` | High |
+| **T7** | **Server TUN & Forwarding**: In `onebox-server`, implement TUN interface creation and basic NAT/forwarding rules. | FR-S-01, FR-S-04 | N/A | `Done` | High |
 
 ### Phase 3: Core Bonding Engine
 

--- a/onebox-server/Cargo.toml
+++ b/onebox-server/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 [dependencies]
 onebox-core = { path = "../onebox-core" }
 tokio = { workspace = true }
+tokio-tun = "0.4.0"
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 clap = { workspace = true }


### PR DESCRIPTION
This commit implements the requirements for Task T7: Server TUN & Forwarding.

The `onebox-server` binary now performs the following actions upon starting:
- Creates a virtual TUN interface (`onebox0`) and assigns it a static IP address (`10.99.99.1/24`).
- Enables kernel IP forwarding by executing `sysctl -w net.ipv4.ip_forward=1`.
- Programmatically determines the default public network interface.
- Sets up an `iptables` NAT rule to masquerade traffic from the TUN subnet to the public interface.

This required adding the `tokio-tun` dependency and implementing helper functions to execute and parse the output of system commands (`ip`, `sysctl`, `iptables`).

The `TASKS.md` and `changelog/UNRELEASED.md` files have been updated to reflect the completion of this task.