### PR TITLE
feat(client, server): Implement T14 Link Health Probing

### DIFF
--- a/changelog/UNRELEASED.md
+++ b/changelog/UNRELEASED.md
@@ -16,6 +16,7 @@ This document tracks upcoming changes and features that are planned for future r
 - **Sequencing & Reassembly**: Added a `PacketHeader` with a sequence number to all upstream packets. Implemented a jitter buffer on the server to reorder packets, ensuring in-order delivery to the TUN interface. (T11)
 - **Symmetric Encryption**: Implemented end-to-end encryption for all tunnel traffic using ChaCha20-Poly1305. Keys are derived from the PSK using BLAKE3. This provides both confidentiality and per-packet authentication. (T12)
 - **Secure Handshake**: Implemented a simple handshake protocol. The client now sends an `AuthRequest` to establish a session, and the server validates it before accepting data packets. (T13)
+- **Link Health Probing**: Implemented a client-side keep-alive mechanism to measure link latency and loss via periodic, authenticated probes. The server now echoes these probes. (T14)
 
 ### Planned Features
 - **Basic Networking**: UDP server and client communication
@@ -70,7 +71,7 @@ This document tracks upcoming changes and features that are planned for future r
 - **T13**: Secure Handshake - `Done`
 
 ### Phase 5: Link Health & Failover (Planned)
-- **T14**: Link Health Probing - `To Do`
+- **T14**: Link Health Probing - `Done`
 - **T15**: Failover Logic - `To Do`
 - **T16**: Link Recovery Logic - `To Do`
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -49,7 +49,7 @@ This document contains the complete list of tasks required to implement the oneb
 
 | ID | Task Description | Related SRS | Related Tests | Status | Priority |
 |----|------------------|--------------|---------------|---------|----------|
-| **T14** | **Link Health Probing**: Implement the client-side keep-alive mechanism to measure link latency and loss. | FR-C-07 | N/A | `To Do` | Medium |
+| **T14** | **Link Health Probing**: Implement the client-side keep-alive mechanism to measure link latency and loss. | FR-C-07 | N/A | `Done` | Medium |
 | **T15** | **Failover Logic**: Implement the client-side logic to mark links as "Down" based on probe failures and remove them from the distribution pool. | FR-C-08 | TS2.1, TS2.3, TS5.1 | `To Do` | Medium |
 | **T16** | **Link Recovery Logic**: Implement the logic to probe "Down" links and mark them as "Up" upon successful recovery. | FR-C-08 | TS2.2 | `To Do` | Medium |
 

--- a/onebox-client/src/health.rs
+++ b/onebox-client/src/health.rs
@@ -1,0 +1,62 @@
+//! Health monitoring for network links.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+/// Represents the status of a network link.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LinkStatus {
+    /// The link is considered up and healthy.
+    Up,
+    /// The link is considered down due to probe failures.
+    Down,
+    /// The link is in an unknown state, awaiting first probe result.
+    Unknown,
+}
+
+/// Holds health statistics for a single network link.
+#[derive(Debug, Clone)]
+pub struct LinkStats {
+    /// The current status of the link.
+    pub status: LinkStatus,
+    /// The last measured Round-Trip Time (RTT).
+    pub rtt: Duration,
+    /// The number of probes sent.
+    pub probes_sent: u64,
+    /// The number of probe echoes received.
+    pub probes_received: u64,
+    /// A map of sent probe sequence numbers to the time they were sent.
+    pub in_flight_probes: HashMap<u64, Instant>,
+    /// The next sequence number to use for a probe on this link.
+    pub next_probe_seq: u64,
+}
+
+impl LinkStats {
+    /// Creates a new `LinkStats` with default values.
+    pub fn new() -> Self {
+        Self {
+            status: LinkStatus::Unknown,
+            rtt: Duration::default(),
+            probes_sent: 0,
+            probes_received: 0,
+            in_flight_probes: HashMap::new(),
+            next_probe_seq: 0,
+        }
+    }
+
+    /// Calculates the current packet loss percentage.
+    pub fn packet_loss_percent(&self) -> f32 {
+        if self.probes_sent == 0 {
+            0.0
+        } else {
+            let loss = self.probes_sent.saturating_sub(self.probes_received);
+            (loss as f32 / self.probes_sent as f32) * 100.0
+        }
+    }
+}
+
+impl Default for LinkStats {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
This commit introduces the link health probing mechanism as defined in task T14.

The `onebox-client` is updated to continuously monitor the health of each available WAN link. It achieves this by:
- Spawning a dedicated Tokio task for each link that periodically sends a `Probe` packet.
- Using a sequence-number-based system with a monotonic clock (`Instant`) to accurately track in-flight probes and calculate Round-Trip Time (RTT).
- Storing link statistics (Status, RTT, packet loss) in a shared `LinkStats` struct.
- Updating the downstream packet processing pipeline to handle probe echoes from the server and update the corresponding link's stats.

The `onebox-server` is updated to recognize and echo these `Probe` packets from authenticated clients, enabling the client's RTT calculation.

This change is foundational for future link failover (T15) and recovery (T16) logic.