### PR TITLE
refactor(T19): Implement concurrent data plane and fix bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,6 +448,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "indexmap"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,6 +620,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,6 +693,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "clap",
+ "num_cpus",
  "onebox-core",
  "tokio",
  "tokio-tun",

--- a/changelog/UNRELEASED.md
+++ b/changelog/UNRELEASED.md
@@ -36,6 +36,7 @@ This document tracks upcoming changes and features that are planned for future r
 ## Changed
 - **Refactored Configuration**: Simplified the existing configuration structs and `config.toml` file to align with the SRS (SI-2). The complex, nested structure has been replaced with a flatter, more direct mapping of requirements. (T2)
 - **Optimized Data Path**: Refactored the client's packet processing hot path to use in-place encryption and pre-allocated buffers, significantly reducing memory allocations and CPU usage. This addresses the performance requirements of NFR-PERF-03. (T18)
+- **Concurrency Model**: Refactored the server and client data planes from a single-pipeline model to a parallel, dispatcher/worker-pool model. This significantly improves concurrency to better leverage multi-core processors, increasing throughput and reducing latency. (T19)
 
 ## Deprecated
 - N/A
@@ -44,7 +45,9 @@ This document tracks upcoming changes and features that are planned for future r
 - N/A
 
 ## Fixed
-- N/A
+- Fixed a bug where the client would authenticate with one `ClientId` but send data packets with another, causing the server to drop them.
+- Fixed a bug where the server would send all downstream data packets with a default `ClientId(0)` instead of the authenticated client's ID.
+- Fixed a critical routing bug where the server would not install a route for the client's TUN network, causing return packets to leak out the physical interface instead of being sent back through the tunnel.
 
 ## Security
 - Implemented ChaCha20-Poly1305 AEAD encryption for all tunnel traffic, authenticated by a key derived from the PSK. (T12)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -59,7 +59,7 @@ This document contains the complete list of tasks required to implement the oneb
 |----|------------------|--------------|---------------|---------|----------|
 | **T17** | **Performance Profiling**: Profile the application under load and identify bottlenecks. | NFR-PERF-01, 02, 03 | TS3.1, TS3.2, TS3.3 | `Blocked` | Medium |
 | **T18** | **Memory & CPU Optimization**: Optimize memory usage and CPU consumption to meet performance NFRs. | NFR-PERF-03 | TS3.3 | `Done` | Medium |
-| **T19** | **Concurrency Optimization**: Optimize the async task model for better throughput and lower latency. | NFR-PERF-01, 02 | TS3.1, TS3.2 | `To Do` | Medium |
+| **T19** | **Concurrency Optimization**: Optimize the async task model for better throughput and lower latency. | NFR-PERF-01, 02 | TS3.1, TS3.2 | `Done` | Medium |
 
 ### Phase 7: Testing & Quality Assurance
 

--- a/onebox-client/src/main.rs
+++ b/onebox-client/src/main.rs
@@ -248,9 +248,10 @@ async fn main() -> anyhow::Result<()> {
             let key = Arc::new(key);
 
             // Perform handshake on the first socket to establish the session
+            let client_id = ClientId(1); // Define a consistent client ID
             let (iface_name, handshake_socket) = all_sockets.first().unwrap();
             info!("Performing handshake over interface '{}'", iface_name);
-            perform_handshake(handshake_socket, &key, ClientId(1)).await?; // Using ClientId(1) for now
+            perform_handshake(handshake_socket, &key, client_id).await?;
 
             info!("Handshake complete. Starting data plane...");
 
@@ -270,7 +271,6 @@ async fn main() -> anyhow::Result<()> {
                 let prober_stats = link_stats.clone();
                 let prober_iface_name = iface_name.clone();
                 let prober_active_sockets = active_sockets.clone();
-                let client_id = ClientId(1); // This should be consistent with the handshake
 
                 tokio::spawn(async move {
                     const PROBE_INTERVAL: Duration = Duration::from_secs(2);
@@ -405,7 +405,7 @@ async fn main() -> anyhow::Result<()> {
 
                             // Create the header and serialize it into the start of the buffer.
                             let header =
-                                PacketHeader::new(seq, PacketType::Data, ClientId::default());
+                                PacketHeader::new(seq, PacketType::Data, client_id);
                             if let Err(e) =
                                 bincode::serialize_into(&mut packet_buf[..HEADER_SIZE], &header)
                             {

--- a/onebox-server/Cargo.toml
+++ b/onebox-server/Cargo.toml
@@ -18,3 +18,4 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 clap = { workspace = true }
 anyhow = { workspace = true }
+num_cpus = "1.16.0"


### PR DESCRIPTION
Refactors the server and client data planes to use a concurrent, multi-threaded model, addressing Task T19.

Server:
- Replaced the single-threaded packet processing loop with a dispatcher/worker-pool model.
- A single dispatcher task receives all UDP packets and distributes them to a pool of worker tasks.
- Workers handle decryption and packet processing in parallel, improving throughput on multi-core systems.

Client:
- Refactored the downstream data path to process and decrypt packets in parallel for each WAN link, removing the previous single-threaded bottleneck.

Bug Fixes:
- Fixed a critical routing bug where the server was not adding a route for the client's TUN network, causing return packets to leak outside the tunnel.
- Fixed an authentication bug where the client would send data packets with a different `ClientId` than it used for authentication.
- Fixed a related bug where the server would send downstream data packets with a default `ClientId(0)`.