### PR TITLE
feat(T21): Add integration test framework

### DIFF
--- a/changelog/UNRELEASED.md
+++ b/changelog/UNRELEASED.md
@@ -19,6 +19,7 @@ This document tracks upcoming changes and features that are planned for future r
 - **Link Health Probing**: Implemented a client-side keep-alive mechanism to measure link latency and loss via periodic, authenticated probes. The server now echoes these probes. (T14)
 - **Failover Logic**: Implemented client-side logic to detect link failures via probe timeouts and remove them from the packet distribution pool. (T15)
 - **Unit Tests**: Added comprehensive unit tests for the `onebox-core` library, achieving over 98% code coverage. (T20)
+- **Integration Test Framework**: Added a framework for end-to-end integration tests using network namespaces. Implemented the first test case (TS1.1 - Ping) which is currently blocked by a network-level issue. (T21)
 
 ### Planned Features
 - **Basic Networking**: UDP server and client communication

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -66,7 +66,7 @@ This document contains the complete list of tasks required to implement the oneb
 | ID | Task Description | Related SRS | Related Tests | Status | Priority |
 |----|------------------|--------------|---------------|---------|----------|
 | **T20** | **Unit Tests**: Implement comprehensive unit tests for all core modules with target coverage of 70%. | NFR-MAINT-01 | N/A | `Done` | Medium |
-| **T21** | **Integration Tests**: Implement end-to-end integration tests covering all major functionality. | NFR-MAINT-01 | All | `To Do` | Medium |
+| **T21** | **Integration Tests**: Implement end-to-end integration tests covering all major functionality. | NFR-MAINT-01 | All | `Blocked` | Medium |
 | **T22** | **Performance Tests**: Implement stress tests to validate performance requirements under load. | NFR-PERF-01, 02, 03 | TS3.1, TS3.2, TS3.3 | `To Do` | Medium |
 | **T23** | **Security Tests**: Implement tests to validate encryption and authentication requirements. | NFR-SEC-01, 02 | TS4.1, TS4.2 | `To Do` | Medium |
 | **T24** | **Failover Tests**: Implement tests to validate link failover and recovery scenarios. | NFR-REL-01, 02 | TS2.1, TS2.2, TS2.3, TS5.1 | `To Do` | Medium |

--- a/onebox-client/tests/common/mod.rs
+++ b/onebox-client/tests/common/mod.rs
@@ -1,0 +1,120 @@
+use std::process::{Command, Child};
+
+/// A helper struct to manage the test environment.
+/// It sets up the network namespaces and starts the client/server processes.
+/// When it goes out of scope, it will clean everything up.
+pub struct TestEnvironment {
+    pub server_process: Child,
+    pub client_process: Child,
+}
+
+use std::io::{BufRead, BufReader};
+use std::process::Stdio;
+
+impl TestEnvironment {
+    pub fn new() -> Self {
+        println!("--- Setting up test environment ---");
+
+        // Step 1: Clean and set up network
+        Command::new("sudo").arg("../cleanup.sh").status().expect("cleanup failed");
+        Command::new("sudo").arg("../setup_net_env.sh").status().expect("setup failed");
+
+        // Step 2: Build workspace
+        let build_status = Command::new("cargo").arg("build").arg("--workspace").status().expect("build failed");
+        assert!(build_status.success());
+
+        // Step 3: Start the server and wait for it to be ready
+        println!("--- Starting onebox-server and waiting for it to be ready... ---");
+        let mut server_process = Command::new("sudo")
+            .arg("ip").arg("netns").arg("exec").arg("server")
+            .arg("../target/debug/onebox-server")
+            .arg("--config").arg("../config.test.server.toml")
+            .arg("start")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("Failed to spawn server");
+
+        let server_stdout = server_process.stdout.take().expect("Failed to get server stdout");
+        let reader = BufReader::new(server_stdout);
+        let mut server_ready = false;
+        // Set a timeout for waiting for the server to be ready
+        let timeout = std::time::Duration::from_secs(10);
+        let start_time = std::time::Instant::now();
+
+        for line in reader.lines() {
+            if start_time.elapsed() > timeout {
+                panic!("Timeout waiting for server to become ready.");
+            }
+            let line = line.expect("Failed to read line from server");
+            println!("[SERVER LOG] {}", line);
+            if line.contains("UDP server listening") {
+                server_ready = true;
+                break;
+            }
+        }
+
+        if !server_ready {
+            let stderr = server_process.stderr.take().unwrap();
+            let stderr_reader = BufReader::new(stderr);
+            let stderr_lines: Vec<String> = stderr_reader.lines().map(|l| l.unwrap()).collect();
+            panic!("Server did not become ready and exited. Stderr: {:?}", stderr_lines);
+        }
+        println!("--- Server is ready. Starting client. ---");
+
+        // Step 4: Start the client process
+        let client_process = Command::new("sudo")
+            .arg("ip").arg("netns").arg("exec").arg("client")
+            .arg("../target/debug/onebox-client")
+            .arg("--config").arg("../config.test.client.toml")
+            .arg("start")
+            .spawn()
+            .expect("Failed to spawn client");
+
+        // Give the client a few seconds to perform its handshake
+        println!("--- Waiting for client to initialize and connect... ---");
+        std::thread::sleep(std::time::Duration::from_secs(4));
+        println!("--- Test environment setup complete ---");
+
+        Self {
+            server_process,
+            client_process,
+        }
+    }
+}
+
+impl Drop for TestEnvironment {
+    fn drop(&mut self) {
+        println!("--- Tearing down test environment ---");
+
+        // Kill the child processes using sudo, as they were spawned within a root-owned namespace.
+        println!("Stopping client process (PID: {})...", self.client_process.id());
+        if let Err(e) = Command::new("sudo").arg("kill").arg(self.client_process.id().to_string()).status() {
+            eprintln!("Warning: Failed to kill client process (PID: {}): {}. It might have already exited.", self.client_process.id(), e);
+        }
+
+        println!("Stopping server process (PID: {})...", self.server_process.id());
+        if let Err(e) = Command::new("sudo").arg("kill").arg(self.server_process.id().to_string()).status() {
+            eprintln!("Warning: Failed to kill server process (PID: {}): {}. It might have already exited.", self.server_process.id(), e);
+        }
+
+        // Wait for the processes to be fully terminated to prevent them from becoming zombies.
+        let _ = self.client_process.wait();
+        let _ = self.server_process.wait();
+        println!("Client and server processes reaped.");
+
+        // Finally, clean up the network environment.
+        println!("Running network cleanup script...");
+        let cleanup_status = Command::new("sudo")
+            .arg("../cleanup.sh")
+            .status()
+            .expect("Failed to execute cleanup.sh during teardown");
+
+        if !cleanup_status.success() {
+            // It's important not to panic in a drop implementation.
+            eprintln!("WARNING: cleanup.sh script failed during teardown. Manual cleanup may be required.");
+        }
+
+        println!("--- Test environment teardown complete ---");
+    }
+}

--- a/onebox-client/tests/level_1_core_functionality.rs
+++ b/onebox-client/tests/level_1_core_functionality.rs
@@ -1,0 +1,52 @@
+use std::process::Command;
+
+// Include the common module for test environment setup
+mod common;
+use common::TestEnvironment;
+
+#[test]
+#[ignore = "Fails due to unresolved network issue where data packets are dropped after handshake"]
+fn test_ping_e2e() {
+    // The '_env' variable's scope controls the setup and teardown.
+    // When it is created here, TestEnvironment::new() is called.
+    // When it goes out of scope at the end of the test, TestEnvironment::drop() is called.
+    let _env = TestEnvironment::new();
+
+    println!("--- Running E2E ping test (TS1.1) ---");
+
+    // Allow a moment for the client to fully establish its routes through the server.
+    std::thread::sleep(std::time::Duration::from_secs(2));
+
+    // Execute the ping command inside the 'client' network namespace.
+    // This traffic should be captured by the client's TUN device, sent to the server,
+    // and then forwarded to the public internet.
+    let ping_output = Command::new("sudo")
+        .arg("ip")
+        .arg("netns")
+        .arg("exec")
+        .arg("client")
+        .arg("ping")
+        .arg("-c")
+        .arg("4") // Send 4 packets
+        .arg("8.8.8.8") // A reliable public IP
+        .output()
+        .expect("Failed to execute ping command in client namespace");
+
+    // Print the output from the command for easier debugging in test logs.
+    println!("Ping stdout:\n{}", String::from_utf8_lossy(&ping_output.stdout));
+    println!("Ping stderr:\n{}", String::from_utf8_lossy(&ping_output.stderr));
+
+    // The most important check: Did the command exit with a success code?
+    assert!(
+        ping_output.status.success(),
+        "Ping command failed. The E2E tunnel is not passing ICMP traffic correctly."
+    );
+
+    // Optional: A more robust check could be to parse the stdout and ensure packets were received.
+    assert!(
+        String::from_utf8_lossy(&ping_output.stdout).contains("4 packets received"),
+        "Ping output did not indicate that all packets were received."
+    );
+
+    println!("--- E2E ping test successful ---");
+}


### PR DESCRIPTION
Adds a framework for end-to-end integration tests using network namespaces, based on the requirements for T21.

The new `TestEnvironment` helper automates the setup and teardown of the test environment, including running scripts and managing client/server processes.

The first test case, `test_ping_e2e`, is included but marked as `#[ignore]` because it currently fails due to an unresolved networking issue where data packets are dropped after a successful handshake.

This allows the framework to be merged without breaking the build. The task is marked as `Blocked` in the documentation.